### PR TITLE
src/.stylelintrc

### DIFF
--- a/src/.stylelintrc
+++ b/src/.stylelintrc
@@ -1,1 +1,1 @@
-{ "extends": "stylelint-config-cnn-starter-app }
+{ "extends": "stylelint-config-cnn-starter-app” }


### PR DESCRIPTION
added missing closing quote that created a bug that blocked tests from
being executed.

FIXES this issue https://github.com/cnnlabs/cnn-birdman/issues/1